### PR TITLE
Fix missing ProjectTeamMember type

### DIFF
--- a/src/types/projects.ts
+++ b/src/types/projects.ts
@@ -52,6 +52,17 @@ export interface ProjectTechnology {
   created_at: string
 }
 
+export interface ProjectTeamMember {
+  role_in_project: string
+  allocation_percentage: number
+  team_member: {
+    full_name: string
+    primary_specialization: string
+    seniority_level: string
+    availability_status: string
+  }
+}
+
 export interface ProjectWithDetails extends Project {
   team_members?: ProjectTeamMember[]
   scope_items?: ProjectScopeItem[]


### PR DESCRIPTION
## Summary
- define `ProjectTeamMember` interface so `ProjectWithDetails` compiles

## Testing
- `npx tsc` *(fails: Cannot find module '@supabase/supabase-js')*

------
https://chatgpt.com/codex/tasks/task_e_68641682d048832da87cefb3c59e1521